### PR TITLE
Reflection-free compatibility changes

### DIFF
--- a/src/DnsClient/LookupClient.cs
+++ b/src/DnsClient/LookupClient.cs
@@ -355,7 +355,7 @@ namespace DnsClient
             }
 
             _originalOptions = options;
-            _logger = Logging.LoggerFactory.CreateLogger(GetType().FullName);
+            _logger = Logging.LoggerFactory.CreateLogger("DnsClient.LookupClient");
             _messageHandler = udpHandler ?? new DnsUdpMessageHandler();
             _tcpFallbackHandler = tcpHandler ?? new DnsTcpMessageHandler();
 

--- a/src/DnsClient/NameServer.cs
+++ b/src/DnsClient/NameServer.cs
@@ -246,7 +246,7 @@ namespace DnsClient
 
             var exceptions = new List<Exception>();
 
-            var logger = Logging.LoggerFactory?.CreateLogger(typeof(NameServer).FullName);
+            var logger = Logging.LoggerFactory?.CreateLogger("DnsClient.NameServer");
 
             logger?.LogDebug("Starting to resolve NameServers, skipIPv6SiteLocal:{0}.", skipIPv6SiteLocal);
             try


### PR DESCRIPTION
APIs that use reflection will throw errors at runtime when publishing in AOT's reflection-free mode. I've changed some params in your logger to use reflection free APIs. The only downside is that now you have to manually maintain the namespace and class names. This change allows your library to work for my use case, but if there is any other use of reflection in other parts of your lib we can fix that too.